### PR TITLE
Add support for Certificate Subject when no Thumbprint is known

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ The cADFS module was created in order to configure certain components of the Mic
 In order to utilize the DSC resources in the cADFS PowerShell module, you will need to ensure that your managed endpoints are using the February 2015 Preview of the Windows Management Framework (WMF) Core package, or later. The reason that this is required, is because the DSC resources provided by cADFS are developed using PowerShell Classes. Building DSC resources using PowerShell Classes was first supported in the WMF 5.0 February 2015 Preview.
 
 # Installation
-To install the cADFS PowerShell module, download it and unzip it to `$env:ProgramFiles\WindowsPowerShell\Modules`.
+To install the cADFS PowerShell module, you can install it directly from the PowerShell Gallery by using `Install-Module cADFS` or download it from here and unzip it to `$env:ProgramFiles\WindowsPowerShell\Modules`.
 
 # Author
-The author of this module is Trevor Sullivan. You can follow Trevor on Twitter [@pcgeek86](https://twitter.com/pcgeek86) or on his website / blog at http://trevorsullivan.net.
+The original author of this module is Trevor Sullivan. You can follow Trevor on Twitter [@pcgeek86](https://twitter.com/pcgeek86) or on his website / blog at http://trevorsullivan.net.
+
+Maintainence of this module is now handled by Chris Gardner, please raise all issues and PRs on his fork. You can follow Chris on Twitter [@halbaradkenafin](https://twitter.com/halbaradkenafin) or on his blog at [chrislgardner.github.io](https://chrislgardner.github.io).

--- a/cADFS.psd1
+++ b/cADFS.psd1
@@ -31,5 +31,6 @@
         'cADFSFarm';
         'cADFSGlobalAuthenticationPolicy';
         'cADFSRelyingPartyTrust';
+        'cADFSSamlEndpoint';
         );
 }  

--- a/cADFS.psd1
+++ b/cADFS.psd1
@@ -3,7 +3,7 @@
     RootModule = 'cADFS.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0'
+    ModuleVersion = '1.2.0.0'
 
     # ID used to uniquely identify this module
     GUID = '2be44be7-93cf-4c08-8a63-f2a77823ca6b';
@@ -33,4 +33,4 @@
         'cADFSRelyingPartyTrust';
         'cADFSSamlEndpoint';
         );
-}  
+}

--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -45,7 +45,7 @@ function InstallADFSFarm {
         -OverwriteConfiguration:$true `
         -ServiceAccountCredential $serviceCredential;    
 
-    Write-Verbose -Message ('Entering function {0}' -f $CmdletName);
+    Write-Verbose -Message ('Leaving function {0}' -f $CmdletName);
 }
 
 [DscResource()]

--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -11,14 +11,16 @@ function InstallADFSFarm {
 
     .Parameter
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='CertificateThumbprint')]
     param (
         [Parameter(Mandatory = $true)]
         [pscredential] $ServiceCredential,
         [Parameter(Mandatory = $true)]
         [pscredential] $InstallCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName='CertificateThumbprint')]
         [string] $CertificateThumbprint,
+        [Parameter(Mandatory = $true, ParameterSetName='CertificateSubject')]
+        [string] $CertificateSubject,
         [Parameter(Mandatory = $true)]
         [string] $DisplayName,
         [Parameter(Mandatory = $true)]
@@ -27,6 +29,11 @@ function InstallADFSFarm {
     )
 
     $CmdletName = $PSCmdlet.MyInvocation.MyCommand.Name;
+
+    if ($PSBoundParameters.CertificateSubject) {
+        $Certificate = Find-Certificate -Subject $CertificateSubject
+        $CertificateThumbprint = $Certificate.Thumbprint
+    }
 
     Write-Verbose -Message ('Entering function {0}' -f $CmdletName);
 
@@ -65,8 +72,15 @@ class cADFSFarm {
     The CertificateThumbprint property is the thumbprint of the certificate, located in the local computer's certificate store, that will be bound to the 
     Active Directory Federation Service (ADFS) farm.
     #>
-    [DscProperty(Mandatory)]
+    [DscProperty()]
     [string] $CertificateThumbprint;
+
+        <#
+    The CertificateSubject property is the subject of the certificate, located in the local computer's certificate store, that will be bound to the 
+    Active Directory Federation Service (ADFS) farm. Used when the certificate thumbprint is not known when generating the MOF.
+    #>
+    [DscProperty()]
+    [string] $CertificateSubject;
 
     <#
     The ServiceCredential property is a PSCredential that represents the username/password that the 
@@ -146,10 +160,17 @@ class cADFSFarm {
                 $AdfsFarm = @{
                     ServiceCredential = $this.ServiceCredential;
                     InstallCredential = $this.InstallCredential;
-                    CertificateThumbprint = $this.CertificateThumbprint;
                     DisplayName = $this.DisplayName;
                     ServiceName = $this.ServiceName;
-                    };
+                };
+                
+                if ($this.CertificateThumbprint) {
+                    $AdfsFarm.Add('CertificateThumbprint',$this.CertificateThumbprint);
+                }
+                elseif ($this.CertificateSubject) {
+                     $AdfsFarm.Add('CertificateSubject',$this.CertificateSubject);
+                }
+
                 InstallADFSFarm @AdfsFarm;
             }
 
@@ -497,6 +518,155 @@ class cADFSGlobalAuthenticationPolicy {
     }
 }
 #endregion
+
+<#
+    .SYNOPSIS
+    Locates one or more certificates using the passed certificate selector parameters.
+
+    If more than one certificate is found matching the selector criteria, they will be
+    returned in order of descending expiration date.
+
+    .PARAMETER Thumbprint
+    The thumbprint of the certificate to find.
+
+    .PARAMETER FriendlyName
+    The friendly name of the certificate to find.
+
+    .PARAMETER Subject
+    The subject of the certificate to find.
+
+    .PARAMETER DNSName
+    The subject alternative name of the certificate to export must contain these values.
+
+    .PARAMETER Issuer
+    The issuer of the certiicate to find.
+
+    .PARAMETER KeyUsage
+    The key usage of the certificate to find must contain these values.
+
+    .PARAMETER EnhancedKeyUsage
+    The enhanced key usage of the certificate to find must contain these values.
+
+    .PARAMETER Store
+    The Windows Certificate Store Name to search for the certificate in.
+    Defaults to 'My'.
+
+    .PARAMETER AllowExpired
+    Allows expired certificates to be returned.
+
+#>
+function Find-Certificate
+{
+    [CmdletBinding()]
+    [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2[]])]
+    param
+    (
+        [Parameter()]
+        [String]
+        $Thumbprint,
+
+        [Parameter()]
+        [String]
+        $FriendlyName,
+
+        [Parameter()]
+        [String]
+        $Subject,
+
+        [Parameter()]
+        [String[]]
+        $DNSName,
+
+        [Parameter()]
+        [String]
+        $Issuer,
+
+        [Parameter()]
+        [String[]]
+        $KeyUsage,
+
+        [Parameter()]
+        [String[]]
+        $EnhancedKeyUsage,
+
+        [Parameter()]
+        [String]
+        $Store = 'My',
+
+        [Parameter()]
+        [Boolean]
+        $AllowExpired = $false
+    )
+
+    $certPath = Join-Path -Path 'Cert:\LocalMachine' -ChildPath $Store
+
+    if (-not (Test-Path -Path $certPath))
+    {
+        # The Certificte Path is not valid
+        New-InvalidArgumentError `
+            -ErrorId 'CannotFindCertificatePath' `
+            -ErrorMessage ($LocalizedData.CertificatePathError -f $certPath)
+    } # if
+
+    # Assemble the filter to use to select the certificate
+    $certFilters = @()
+    if ($PSBoundParameters.ContainsKey('Thumbprint'))
+    {
+        $certFilters += @('($_.Thumbprint -eq $Thumbprint)')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('FriendlyName'))
+    {
+        $certFilters += @('($_.FriendlyName -eq $FriendlyName)')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('Subject'))
+    {
+        $certFilters += @('($_.Subject -eq $Subject)')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('Issuer'))
+    {
+        $certFilters += @('($_.Issuer -eq $Issuer)')
+    } # if
+
+    if (-not $AllowExpired)
+    {
+        $certFilters += @('(((Get-Date) -le $_.NotAfter) -and ((Get-Date) -ge $_.NotBefore))')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('DNSName'))
+    {
+        $certFilters += @('(@(Compare-Object -ReferenceObject $_.DNSNameList.Unicode -DifferenceObject $DNSName | Where-Object -Property SideIndicator -eq "=>").Count -eq 0)')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('KeyUsage'))
+    {
+        $certFilters += @('(@(Compare-Object -ReferenceObject ($_.Extensions.KeyUsages -split ", ") -DifferenceObject $KeyUsage | Where-Object -Property SideIndicator -eq "=>").Count -eq 0)')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('EnhancedKeyUsage'))
+    {
+        $certFilters += @('(@(Compare-Object -ReferenceObject ($_.EnhancedKeyUsageList.FriendlyName) -DifferenceObject $EnhancedKeyUsage | Where-Object -Property SideIndicator -eq "=>").Count -eq 0)')
+    } # if
+
+    # Join all the filters together
+    $certFilterScript = '(' + ($certFilters -join ' -and ') + ')'
+
+    Write-Verbose -Message ($LocalizedData.SearchingForCertificateUsingFilters `
+        -f $store,$certFilterScript)
+
+    $certs = Get-ChildItem -Path $certPath |
+        Where-Object -FilterScript ([ScriptBlock]::Create($certFilterScript))
+
+    # Sort the certificates
+    if ($certs.count -gt 1)
+    {
+        $certs = $certs | Sort-Object -Descending -Property 'NotAfter'
+    } # if
+
+    return $certs
+} # end function Find-Certificate
 
 return;
 

--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -217,6 +217,10 @@ class cADFSRelyingPartyTrust {
     [DscProperty()]
     [string] $ProtocolProfile;
 
+    ### Specifies the name of an access control policy
+    [DscProperty()]
+    [string] $AccessControlPolicyName;
+
     [cADFSRelyingPartyTrust] Get() {
         $this.CheckDependencies();
 
@@ -238,6 +242,7 @@ class cADFSRelyingPartyTrust {
         $this.WsFederationEndpoint = $RelyingPartyTrust.WsFedEndpoint;
         $this.Notes = $RelyingPartyTrust.Notes;
         $this.Identifier = $RelyingPartyTrust.Identifier;
+        $this.AccessControlPolicyName = $RelyingPartyTrust.AccessControlPolicyName;
 
         return $this;
     }
@@ -313,6 +318,10 @@ class cADFSRelyingPartyTrust {
             Write-Verbose -Message ('The current Notes property value ({0}) does not match the desired configuration ({1}).' -f $RelyingPartyTrust.Notes, $this.Notes);
             $Compliant = $false;
         }
+        if ($RelyingPartyTrust.AccessControlPolicyName -ne $this.AccessControlPolicyName) {
+            Write-Verbose -Message ('The current AccessControlPolicyName property value ({0}) does not match the desired configuration ({1}).' -f $RelyingPartyTrust.AccessControlPolicyName, $this.AccessControlPolicyName);
+            $Compliant = $false;
+        }
 
         if ($Compliant) {
             Write-Verbose -Message ('ADFS Relying Party ({0}) is compliant' -f $this.Name);
@@ -342,6 +351,10 @@ class cADFSRelyingPartyTrust {
 
         if ($this.IssuanceAuthorizationRules) {
             $RelyingPartyTrust.Add('IssuanceAuthorizationRules', $this.IssuanceAuthorizationRules);
+        }
+
+        if ($this.AccessControlPolicyName) {
+            $RelyingPartyTrust.Add('AccessControlPolicyName', $this.AccessControlPolicyName);
         }
 
         ### Retrieve the existing Relying Party Configuration

--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -170,6 +170,9 @@ class cADFSFarm {
                 elseif ($this.CertificateSubject) {
                      $AdfsFarm.Add('CertificateSubject',$this.CertificateSubject);
                 }
+                else {
+                    Throw "No Certificate details provided, cannot configure ADFS Farm."
+                }
 
                 InstallADFSFarm @AdfsFarm;
             }


### PR DESCRIPTION
This will allow a configuration to be supplied a subject instead of a thumbprint for creating the farm. Particularly of use when you are generating the certificate (using xCertReq or similar) in the same configuration as the farm creation and don't know the thumbprint but do know the subject. Uses a function that is part of xWebAdministration to find the certificate so can be expanded to accept more properties to be more specific to find the certificate.

I did have to remove Mandatory from CertificateThumbprint but added some error handling in to check if both it and CertificateSubject are empty. 